### PR TITLE
Adiciona suporte a métricas com Micrometer e Prometheus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,12 @@
 			<artifactId>jackson-datatype-jsr310</artifactId>
 			<version>2.18.2</version>
 		</dependency>
+		<!-- Micrometer Core -->
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-core</artifactId>
+		</dependency>
+		<!-- Micrometer Prometheus Registry -->
 		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-registry-prometheus</artifactId>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,15 @@ management:
   endpoints:
     web:
       exposure:
-        include: "*"
+        include: prometheus,health,metrics
   endpoint:
-    health:
-      show-details: always
+    prometheus:
+      enabled: 'true'
+      health:
+        show-details: always
+    metrics:
+        enabled: 'true'
+  metrics:
+        export:
+          prometheus:
+            enabled: 'true'


### PR DESCRIPTION
### O que foi feito?
- Adicionada a dependência do Micrometer Core e Micrometer Prometheus Registry no `pom.xml`.
- Implementada a coleta de métricas no serviço `GpsPollingService`, incluindo:
  - Contador de dados processados (`gps.data.processed`).
  - Contador de erros (`gps.errors`).
  - Timer para medir o tempo de execução do polling (`gps.polling.timer`).
- Configuração do endpoint do Prometheus no `application.yml` para expor métricas.

### Por que foi feito?
- Para monitorar o desempenho e a saúde do serviço de polling de GPS.
- Para facilitar a identificação de problemas e a análise de métricas em tempo real.
- Para integrar o serviço com ferramentas de monitoramento como Prometheus e Grafana.

### Contexto adicional
- As métricas adicionadas ajudarão a equipe a:
  - Identificar gargalos no processo de polling.
  - Monitorar a quantidade de dados processados e erros ocorridos.
  - Melhorar a confiabilidade e o desempenho do serviço.